### PR TITLE
bug fix: NullPointerException occurs in OnResume.

### DIFF
--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/LegacyCameraConnectionFragment.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/LegacyCameraConnectionFragment.java
@@ -67,7 +67,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
         public void onSurfaceTextureAvailable(
             final SurfaceTexture texture, final int width, final int height) {
           availableSurfaceTexture = texture;
-          startCamera(texture);
+          startCamera();
         }
 
         @Override
@@ -118,7 +118,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
     // the SurfaceTextureListener).
 
     if (textureView.isAvailable()) {
-      startCamera(availableSurfaceTexture);
+      startCamera();
     } else {
       textureView.setSurfaceTextureListener(surfaceTextureListener);
     }
@@ -148,7 +148,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
     }
   }
   
-  private void startCamera(final SurfaceTexture texture) {
+  private void startCamera() {
     int index = getCameraId();
     camera = Camera.open(index);
 
@@ -171,7 +171,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
       parameters.setPreviewSize(previewSize.getWidth(), previewSize.getHeight());
       camera.setDisplayOrientation(90);
       camera.setParameters(parameters);
-      camera.setPreviewTexture(texture);
+      camera.setPreviewTexture(availableSurfaceTexture);
     } catch (IOException exception) {
       camera.release();
     }

--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/LegacyCameraConnectionFragment.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/LegacyCameraConnectionFragment.java
@@ -55,6 +55,8 @@ public class LegacyCameraConnectionFragment extends Fragment {
   private int layout;
   /** An {@link AutoFitTextureView} for camera preview. */
   private AutoFitTextureView textureView;
+  private SurfaceTexture availableSurfaceTexture = null;
+  
   /**
    * {@link TextureView.SurfaceTextureListener} handles several lifecycle events on a {@link
    * TextureView}.
@@ -64,41 +66,8 @@ public class LegacyCameraConnectionFragment extends Fragment {
         @Override
         public void onSurfaceTextureAvailable(
             final SurfaceTexture texture, final int width, final int height) {
-
-          int index = getCameraId();
-          camera = Camera.open(index);
-
-          try {
-            Camera.Parameters parameters = camera.getParameters();
-            List<String> focusModes = parameters.getSupportedFocusModes();
-            if (focusModes != null
-                && focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-              parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
-            }
-            List<Camera.Size> cameraSizes = parameters.getSupportedPreviewSizes();
-            Size[] sizes = new Size[cameraSizes.size()];
-            int i = 0;
-            for (Camera.Size size : cameraSizes) {
-              sizes[i++] = new Size(size.width, size.height);
-            }
-            Size previewSize =
-                CameraConnectionFragment.chooseOptimalSize(
-                    sizes, desiredSize.getWidth(), desiredSize.getHeight());
-            parameters.setPreviewSize(previewSize.getWidth(), previewSize.getHeight());
-            camera.setDisplayOrientation(90);
-            camera.setParameters(parameters);
-            camera.setPreviewTexture(texture);
-          } catch (IOException exception) {
-            camera.release();
-          }
-
-          camera.setPreviewCallbackWithBuffer(imageListener);
-          Camera.Size s = camera.getParameters().getPreviewSize();
-          camera.addCallbackBuffer(new byte[ImageUtils.getYUVByteSize(s.height, s.width)]);
-
-          textureView.setAspectRatio(s.height, s.width);
-
-          camera.startPreview();
+          availableSurfaceTexture = texture;
+          startCamera(texture);
         }
 
         @Override
@@ -149,7 +118,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
     // the SurfaceTextureListener).
 
     if (textureView.isAvailable()) {
-      camera.startPreview();
+      startCamera(availableSurfaceTexture);
     } else {
       textureView.setSurfaceTextureListener(surfaceTextureListener);
     }
@@ -177,6 +146,43 @@ public class LegacyCameraConnectionFragment extends Fragment {
     } catch (final InterruptedException e) {
       LOGGER.e(e, "Exception!");
     }
+  }
+  
+  private void startCamera(final SurfaceTexture texture) {
+    int index = getCameraId();
+    camera = Camera.open(index);
+
+    try {
+      Camera.Parameters parameters = camera.getParameters();
+      List<String> focusModes = parameters.getSupportedFocusModes();
+      if (focusModes != null
+              && focusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+        parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+      }
+      List<Camera.Size> cameraSizes = parameters.getSupportedPreviewSizes();
+      Size[] sizes = new Size[cameraSizes.size()];
+      int i = 0;
+      for (Camera.Size size : cameraSizes) {
+        sizes[i++] = new Size(size.width, size.height);
+      }
+      Size previewSize =
+              CameraConnectionFragment.chooseOptimalSize(
+                      sizes, desiredSize.getWidth(), desiredSize.getHeight());
+      parameters.setPreviewSize(previewSize.getWidth(), previewSize.getHeight());
+      camera.setDisplayOrientation(90);
+      camera.setParameters(parameters);
+      camera.setPreviewTexture(texture);
+    } catch (IOException exception) {
+      camera.release();
+    }
+
+    camera.setPreviewCallbackWithBuffer(imageListener);
+    Camera.Size s = camera.getParameters().getPreviewSize();
+    camera.addCallbackBuffer(new byte[ImageUtils.getYUVByteSize(s.height, s.width)]);
+
+    textureView.setAspectRatio(s.height, s.width);
+
+    camera.startPreview();
   }
 
   protected void stopCamera() {

--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/LegacyCameraConnectionFragment.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/LegacyCameraConnectionFragment.java
@@ -56,7 +56,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
   /** An {@link AutoFitTextureView} for camera preview. */
   private AutoFitTextureView textureView;
   private SurfaceTexture availableSurfaceTexture = null;
-  
+
   /**
    * {@link TextureView.SurfaceTextureListener} handles several lifecycle events on a {@link
    * TextureView}.
@@ -147,7 +147,7 @@ public class LegacyCameraConnectionFragment extends Fragment {
       LOGGER.e(e, "Exception!");
     }
   }
-  
+
   private void startCamera() {
     int index = getCameraId();
     camera = Camera.open(index);


### PR DESCRIPTION
After `onPause` executes, camera will be released and set to be null. If `onResume` executes next, **camera is null** and `NullPointerException` occurs: `camera.startPreview();`, so we should reopen the camera again.

Reproduce this issue:
1. Open the object detection page.
2. Switch to home page by press home button to trigger the execution of `onPause`.
3. Switch back to the object detection page to trigger the execution of `onResume`. Then `NullPointerException` occurs.

So I think we should move the camera setup operations into one standalone method. Then we can share these operations in these two conditions:
1. Open the camera when SurfaceTexture is ready.
2. Reopen the camera in `onResume`.